### PR TITLE
unable to start as python manage.py celery mon

### DIFF
--- a/celerymon/bin/celerymon.py
+++ b/celerymon/bin/celerymon.py
@@ -52,15 +52,17 @@ Configuration ->
 OPTION_LIST = (
 )
 
+PID_FILE = 'celerymon.pid'
+
 
 class MonitorCommand(Command):
     namespace = 'celerymon'
     enable_config_from_cmdline = True
-    preload_options = Command.preload_options + daemon_options('celerymon.pid')
+    preload_options = Command.preload_options + daemon_options(PID_FILE)
     version = __version__
 
     def run(self, loglevel='ERROR', logfile=None, http_port=8989,
-            http_address='', app=None, detach=False, pidfile=None,
+            http_address='', app=None, detach=False, pidfile=PID_FILE,
             uid=None, gid=None, umask=None, working_directory=None, **kwargs):
         print('celerymon %s is starting.' % self.version)
         app = self.app


### PR DESCRIPTION
Hi !

I'm able to start as python manage.py celerymon, but if I run

python manage.py celery mon

it fails: 

celerymon 1.0.3 is starting.
Configuration ->
    . broker -> amqp://imax@localhost:5672/mws
    . webserver -> http://localhost:8989
celerymon has started.
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_manager(settings)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/django/core/management/__init__.py", line 459, in execute_manager
    utility.execute()
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/djcelery/management/commands/celery.py", line 22, in run_from_argv
    ["%s %s" % (argv[0], argv[1])] + argv[2:])
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 890, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/base.py", line 179, in execute_from_commandline
    return self.handle_argv(prog_name, argv[1:])
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 882, in handle_argv
    return self.execute(command, argv)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 857, in execute
    return cls(app=self.app).run_from_argv(self.prog_name, argv)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 142, in run_from_argv
    return self(*args, **options)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 112, in __call__
    ret = self.run(*args, **kwargs)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/bin/celery.py", line 214, in run
    return self.target.run(*args, **kwargs)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celerymon-1.0.3-py2.7.egg/celerymon/bin/celerymon.py", line 105, in run
    _run_monitor()
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celerymon-1.0.3-py2.7.egg/celerymon/bin/celerymon.py", line 85, in _run_monitor
    create_pidlock(pidfile)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/platforms.py", line 241, in create_pidlock
    pidlock = _create_pidlock(pidfile)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/platforms.py", line 247, in _create_pidlock
    pidlock = Pidfile(pidfile)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/site-packages/celery/platforms.py", line 132, in __init__
    self.path = os.path.abspath(path)
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/posixpath.py", line 343, in abspath
    if not isabs(path):
  File "/home/alecs/workspace/envs/imaxenv/lib/python2.7/posixpath.py", line 53, in isabs
    return s.startswith('/')
AttributeError: 'NoneType' object has no attribute 'startswith'